### PR TITLE
Update default value for "wait_for_update" parameter to 300 milliseconds.

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,12 @@ homepage: "https://github.com/mtechraw/consent-mode-gtm"
 documentation: "https://github.com/mtechraw/consent-mode-gtm/blob/main/README.md"
 versions:
   # Latest version
+  
+  - sha: b122b3ad383cf8696c5c9607a7358f67cc31ea37 
+    changeNotes: updated wait_for_update to 300 ms
+  # Older versions
   - sha: 8cb6278e0fb8b1a8ac51eb045a11e65bd708e9d9 
     changeNotes: updated wait_for_update to 200 ms
-  # Older versions
   - sha: 8e4f5c0e663d99887ab08ed4995ed9616def6b47 
     changeNotes: Add new categories to template.tpl
   - sha: 7afeb2c5f74d263bc014ebd5f5c54e6e31fc0a4a 

--- a/template.tpl
+++ b/template.tpl
@@ -53,7 +53,7 @@ ___TEMPLATE_PARAMETERS___
     "name": "wait_for_update",
     "displayName": "Wait for Update",
     "simpleValueType": true,
-    "defaultValue": 200,
+    "defaultValue": 300,
     "help": "How long to wait (in milliseconds) for an \u003cstrong\u003eUpdate\u003c/strong\u003e command before firing Google tags that have been queued up."
   },
   {


### PR DESCRIPTION
Increased the default value of the "wait_for_update" parameter from 200 to 300 milliseconds. This change allows more time for processing before firing Google tags that have been queued up.
